### PR TITLE
fix: AI生成画面イメージの設計書間共有問題を修正

### DIFF
--- a/src/components/Content/MockupSection.tsx
+++ b/src/components/Content/MockupSection.tsx
@@ -280,26 +280,6 @@ ${tableMarkdown}
             </button>
           )}
           
-          {/* テスト用：簡単なHTMLで変換テスト */}
-          <button
-            type="button"
-            className="flex items-center px-3 py-2 bg-purple-600 text-white rounded-lg font-bold shadow-sm hover:bg-purple-700 transition-colors text-sm"
-            onClick={() => {
-              const testHtml = `
-                <div style="font-family: Arial, sans-serif; padding: 20px; background: #f0f9ff; border-radius: 8px;">
-                  <h1 style="color: #1e40af; margin-bottom: 16px;">🧪 テスト画面</h1>
-                  <p style="color: #374151; margin-bottom: 12px;">これは画像変換のテスト用HTMLです。</p>
-                  <div style="background: #3b82f6; color: white; padding: 10px; border-radius: 4px; text-align: center;">
-                    画像変換テスト成功！
-                  </div>
-                </div>
-              `;
-              setAiHtml(testHtml);
-            }}
-          >
-            🧪 テスト用HTML
-          </button>
-          
           <span className="text-xs text-gray-500">PNG,JPG,GIF対応 | HTML+CSS自動生成 | 画像変換</span>
         </div>
 

--- a/src/components/Content/MockupSection.tsx
+++ b/src/components/Content/MockupSection.tsx
@@ -241,7 +241,7 @@ ${tableMarkdown}
     <MarkdownSection title="画面イメージ" icon={Image}>
       <div className="space-y-2">
         {/* コントロールボタンエリア - コンパクトに並列配置 */}
-        <div className="flex items-center space-x-3">
+        <div className="flex items-center space-x-4">
           <input
             type="file"
             accept="image/*"
@@ -271,7 +271,8 @@ ${tableMarkdown}
           {aiHtml && (
             <button
               type="button"
-              className="flex items-center px-3 py-2 bg-green-600 text-white rounded-lg font-bold shadow-sm hover:bg-green-700 transition-colors text-sm"
+              className="flex items-center px-3 py-2 bg-gray-200 text-gray-800 border border-gray-400 rounded-lg cursor-pointer hover:bg-gray-300 transition-colors font-bold shadow-sm text-sm"
+              style={{ backgroundColor: '#e5e7eb', color: '#1f2937', fontWeight: 'bold' }}
               onClick={handleCaptureAsImage}
               disabled={isCapturing}
             >

--- a/src/components/Content/MockupSection.tsx
+++ b/src/components/Content/MockupSection.tsx
@@ -13,6 +13,7 @@ interface MockupSectionProps {
   spreadsheetData?: any[];
   aiGeneratedImage?: string | null; // AI生成画像（新規追加）
   onAiImageGenerated?: (imageBase64: string) => void; // AI画像生成時のコールバック
+  documentId?: string; // 設計書ID（新規追加）
 }
 
 const LOCAL_STORAGE_KEY = 'ai-mockup-html';
@@ -62,24 +63,35 @@ export const MockupSection: React.FC<MockupSectionProps> = ({
   spreadsheetData = [],
   aiGeneratedImage,
   onAiImageGenerated,
+  documentId,
 }) => {
   // AI生成HTML+CSS
   const [aiHtml, setAiHtml] = useState<string>('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [isCapturing, setIsCapturing] = useState(false);
 
-  // LocalStorageから初期値読込
-  useEffect(() => {
-    const saved = localStorage.getItem(LOCAL_STORAGE_KEY);
-    if (saved) setAiHtml(saved);
-  }, []);
+  // 設計書別のLocalStorageキー
+  const storageKey = documentId ? `ai-mockup-html-${documentId}` : LOCAL_STORAGE_KEY;
 
-  // LocalStorageへ保存
+  // LocalStorageから初期値読込（設計書別）
+  useEffect(() => {
+    const saved = localStorage.getItem(storageKey);
+    if (saved) {
+      console.log(`📥 AI HTML復元 [${documentId}]:`, saved.length, '文字');
+      setAiHtml(saved);
+    } else {
+      console.log(`📭 AI HTML なし [${documentId}]`);
+      setAiHtml(''); // 明示的にクリア
+    }
+  }, [storageKey, documentId]);
+
+  // LocalStorageへ保存（設計書別）
   useEffect(() => {
     if (aiHtml) {
-      localStorage.setItem(LOCAL_STORAGE_KEY, aiHtml);
+      console.log(`💾 AI HTML保存 [${documentId}]:`, aiHtml.length, '文字');
+      localStorage.setItem(storageKey, aiHtml);
     }
-  }, [aiHtml]);
+  }, [aiHtml, storageKey, documentId]);
 
   // AIで画面イメージ（HTML+CSS）生成
   const handleGenerateAiMockup = useCallback(async () => {

--- a/src/components/Content/MockupSection.tsx
+++ b/src/components/Content/MockupSection.tsx
@@ -77,10 +77,8 @@ export const MockupSection: React.FC<MockupSectionProps> = ({
   useEffect(() => {
     const saved = localStorage.getItem(storageKey);
     if (saved) {
-      console.log(`📥 AI HTML復元 [${documentId}]:`, saved.length, '文字');
       setAiHtml(saved);
     } else {
-      console.log(`📭 AI HTML なし [${documentId}]`);
       setAiHtml(''); // 明示的にクリア
     }
   }, [storageKey, documentId]);
@@ -88,7 +86,6 @@ export const MockupSection: React.FC<MockupSectionProps> = ({
   // LocalStorageへ保存（設計書別）
   useEffect(() => {
     if (aiHtml) {
-      console.log(`💾 AI HTML保存 [${documentId}]:`, aiHtml.length, '文字');
       localStorage.setItem(storageKey, aiHtml);
     }
   }, [aiHtml, storageKey, documentId]);
@@ -407,13 +404,16 @@ ${tableMarkdown}
                     // 画像を新しいタブで開く（デバッグ用）
                     const newWindow = window.open();
                     if (newWindow) {
-                      newWindow.document.write(`
+                      const html = `
                         <html>
                           <body style="margin:0;background:#f0f0f0;display:flex;justify-content:center;align-items:center;min-height:100vh;">
                             <img src="data:image/png;base64,${aiGeneratedImage}" style="max-width:100%;max-height:100%;border:1px solid #ccc;" />
                           </body>
                         </html>
-                      `);
+                      `;
+                      newWindow.document.open();
+                      newWindow.document.write(html);
+                      newWindow.document.close();
                     }
                   }}
                   className="text-xs text-blue-600 hover:text-blue-800 underline"

--- a/src/components/Document/ScreenDocumentView.tsx
+++ b/src/components/Document/ScreenDocumentView.tsx
@@ -66,14 +66,13 @@ export const ScreenDocumentView: React.FC<ScreenDocumentViewProps> = ({
     supplementMarkdown,
     spreadsheetData,
     mockupImage,
+    aiGeneratedImage,
     setConditionsMarkdown,
     setSupplementMarkdown,
     setSpreadsheetData,
     setMockupImage,
+    setAiGeneratedImage,
   } = useDocumentState();
-
-  // AI生成画像の状態管理
-  const [aiGeneratedImage, setAiGeneratedImage] = useState<string | null>(null);
 
   // AI生成画像設定時のデバッグログ
   const handleAiImageGenerated = useCallback((imageBase64: string) => {
@@ -120,15 +119,12 @@ export const ScreenDocumentView: React.FC<ScreenDocumentViewProps> = ({
     setSpreadsheetData(document.spreadsheet || []);
     setMockupImage(document.mockup || null);
     
-    // AI生成画像は初回またはドキュメント変更時のみ設定
-    if (document.aiGeneratedImage && document.aiGeneratedImage !== aiGeneratedImage) {
-      console.log('📥 DocumentからAI生成画像を復元:', document.aiGeneratedImage.length, 'characters');
-      setAiGeneratedImage(document.aiGeneratedImage);
-    } else if (!document.aiGeneratedImage && aiGeneratedImage) {
-      console.log('🔄 DocumentにAI画像なし、現在の状態をクリア');
-      // ドキュメントにAI画像がない場合はクリアしない（新規生成を保持）
+    // AI生成画像は常に設定（クリアも含む）
+    if (document.aiGeneratedImage !== aiGeneratedImage) {
+      console.log('📥 DocumentからAI生成画像を設定:', document.aiGeneratedImage ? `${document.aiGeneratedImage.length} characters` : 'null (クリア)');
+      setAiGeneratedImage(document.aiGeneratedImage || null);
     }
-  }, [document.id, document.conditions, document.supplement, document.spreadsheet, document.mockup, document.aiGeneratedImage, setConditionsMarkdown, setSupplementMarkdown, setSpreadsheetData, setMockupImage]);
+  }, [document.id, document.conditions, document.supplement, document.spreadsheet, document.mockup, document.aiGeneratedImage, setConditionsMarkdown, setSupplementMarkdown, setSpreadsheetData, setMockupImage, setAiGeneratedImage]);
 
   // 基本データの自動保存（AI生成画像以外）
   useEffect(() => {
@@ -284,6 +280,7 @@ export const ScreenDocumentView: React.FC<ScreenDocumentViewProps> = ({
                 spreadsheetData={spreadsheetData}
                 aiGeneratedImage={aiGeneratedImage}
                 onAiImageGenerated={handleAiImageGenerated}
+                documentId={document.id}
               />
               <DefinitionsSection
                 spreadsheetData={spreadsheetData}
@@ -314,6 +311,7 @@ export const ScreenDocumentView: React.FC<ScreenDocumentViewProps> = ({
               spreadsheetData={spreadsheetData}
               aiGeneratedImage={aiGeneratedImage}
               onAiImageGenerated={handleAiImageGenerated}
+              documentId={document.id}
             />
           )}
 

--- a/src/components/Document/ScreenDocumentView.tsx
+++ b/src/components/Document/ScreenDocumentView.tsx
@@ -74,46 +74,17 @@ export const ScreenDocumentView: React.FC<ScreenDocumentViewProps> = ({
     setAiGeneratedImage,
   } = useDocumentState();
 
-  // AI生成画像設定時のデバッグログ
+  // AI生成画像設定
   const handleAiImageGenerated = useCallback((imageBase64: string) => {
-    console.log('🎯 ScreenDocumentView: AI画像受信開始');
-    console.log('🎯 受信データサイズ:', imageBase64?.length || 0, 'characters');
-    console.log('🎯 受信データ先頭:', imageBase64?.substring(0, 50) + '...');
-    
     if (!imageBase64) {
-      console.error('❌ ScreenDocumentView: 受信したAI画像データが空です');
       return;
     }
     
     setAiGeneratedImage(imageBase64);
-    console.log('✅ ScreenDocumentView: AI画像状態を更新しました');
-    
-    // 状態更新の確認（次のレンダリングサイクルで）
-    setTimeout(() => {
-      console.log('🔍 状態更新確認:', {
-        aiGeneratedImageLength: aiGeneratedImage?.length || 0,
-        設定値との一致: aiGeneratedImage === imageBase64
-      });
-    }, 100);
-  }, [aiGeneratedImage]);
-
-  // AI生成画像状態の変更を監視
-  useEffect(() => {
-    console.log('🔄 AI生成画像状態が変更されました:', {
-      存在: !!aiGeneratedImage,
-      サイズ: aiGeneratedImage?.length || 0,
-      タイプ: typeof aiGeneratedImage
-    });
-  }, [aiGeneratedImage]);
+  }, [setAiGeneratedImage]);
 
   // 初期データの設定（画面設計書のフィールドのみ）
   useEffect(() => {
-    console.log('🔄 初期データ設定useEffect実行:', {
-      documentId: document.id,
-      aiGeneratedImageExists: !!document.aiGeneratedImage,
-      currentAiImageExists: !!aiGeneratedImage
-    });
-    
     setConditionsMarkdown(document.conditions || '');
     setSupplementMarkdown(document.supplement || '');
     setSpreadsheetData(document.spreadsheet || []);
@@ -121,7 +92,6 @@ export const ScreenDocumentView: React.FC<ScreenDocumentViewProps> = ({
     
     // AI生成画像は常に設定（クリアも含む）
     if (document.aiGeneratedImage !== aiGeneratedImage) {
-      console.log('📥 DocumentからAI生成画像を設定:', document.aiGeneratedImage ? `${document.aiGeneratedImage.length} characters` : 'null (クリア)');
       setAiGeneratedImage(document.aiGeneratedImage || null);
     }
   }, [document.id, document.conditions, document.supplement, document.spreadsheet, document.mockup, document.aiGeneratedImage, setConditionsMarkdown, setSupplementMarkdown, setSpreadsheetData, setMockupImage, setAiGeneratedImage]);

--- a/src/hooks/useDocumentState.ts
+++ b/src/hooks/useDocumentState.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { 
   initialConditionsMarkdown, 
   initialSupplementMarkdown, 
@@ -7,6 +7,11 @@ import {
 import type { SpreadsheetData } from '../types/spreadsheet';
 
 export const useDocumentState = () => {
+  // インスタンス識別用のランダムID
+  const instanceId = React.useRef(Math.random().toString(36).substr(2, 9)).current;
+  
+  console.log(`🔧 useDocumentState インスタンス作成: ${instanceId}`);
+  
   // Markdownとスプレッドシートの状態
   const [conditionsMarkdown, setConditionsMarkdown] = useState<string>(initialConditionsMarkdown);
   const [supplementMarkdown, setSupplementMarkdown] = useState<string>(initialSupplementMarkdown);
@@ -14,9 +19,21 @@ export const useDocumentState = () => {
   
   // 画像状態
   const [mockupImage, setMockupImage] = useState<string | null>(null);
+  const [aiGeneratedImage, setAiGeneratedImage] = useState<string | null>(null);
   
   // Mermaidコード状態
   const [mermaidCode, setMermaidCode] = useState<string>('');
+  
+  // 状態変更をログに記録
+  const loggedSetMockupImage = React.useCallback((value: string | null) => {
+    console.log(`📸 mockupImage変更 [${instanceId}]:`, value ? `${value.length}文字` : 'null');
+    setMockupImage(value);
+  }, [instanceId]);
+  
+  const loggedSetAiGeneratedImage = React.useCallback((value: string | null) => {
+    console.log(`🤖 aiGeneratedImage変更 [${instanceId}]:`, value ? `${value.length}文字` : 'null');
+    setAiGeneratedImage(value);
+  }, [instanceId]);
 
   return {
     // 状態
@@ -24,13 +41,18 @@ export const useDocumentState = () => {
     supplementMarkdown,
     spreadsheetData,
     mockupImage,
+    aiGeneratedImage,
     mermaidCode,
     
-    // セッター
+    // セッター（ログ付き）
     setConditionsMarkdown,
     setSupplementMarkdown,
     setSpreadsheetData,
-    setMockupImage,
+    setMockupImage: loggedSetMockupImage,
+    setAiGeneratedImage: loggedSetAiGeneratedImage,
     setMermaidCode,
+    
+    // デバッグ情報
+    _instanceId: instanceId,
   };
 };

--- a/src/hooks/useDocumentState.ts
+++ b/src/hooks/useDocumentState.ts
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { 
   initialConditionsMarkdown, 
   initialSupplementMarkdown, 
@@ -7,11 +7,6 @@ import {
 import type { SpreadsheetData } from '../types/spreadsheet';
 
 export const useDocumentState = () => {
-  // インスタンス識別用のランダムID
-  const instanceId = React.useRef(Math.random().toString(36).substr(2, 9)).current;
-  
-  console.log(`🔧 useDocumentState インスタンス作成: ${instanceId}`);
-  
   // Markdownとスプレッドシートの状態
   const [conditionsMarkdown, setConditionsMarkdown] = useState<string>(initialConditionsMarkdown);
   const [supplementMarkdown, setSupplementMarkdown] = useState<string>(initialSupplementMarkdown);
@@ -23,17 +18,6 @@ export const useDocumentState = () => {
   
   // Mermaidコード状態
   const [mermaidCode, setMermaidCode] = useState<string>('');
-  
-  // 状態変更をログに記録
-  const loggedSetMockupImage = React.useCallback((value: string | null) => {
-    console.log(`📸 mockupImage変更 [${instanceId}]:`, value ? `${value.length}文字` : 'null');
-    setMockupImage(value);
-  }, [instanceId]);
-  
-  const loggedSetAiGeneratedImage = React.useCallback((value: string | null) => {
-    console.log(`🤖 aiGeneratedImage変更 [${instanceId}]:`, value ? `${value.length}文字` : 'null');
-    setAiGeneratedImage(value);
-  }, [instanceId]);
 
   return {
     // 状態
@@ -44,15 +28,12 @@ export const useDocumentState = () => {
     aiGeneratedImage,
     mermaidCode,
     
-    // セッター（ログ付き）
+    // セッター
     setConditionsMarkdown,
     setSupplementMarkdown,
     setSpreadsheetData,
-    setMockupImage: loggedSetMockupImage,
-    setAiGeneratedImage: loggedSetAiGeneratedImage,
+    setMockupImage,
+    setAiGeneratedImage,
     setMermaidCode,
-    
-    // デバッグ情報
-    _instanceId: instanceId,
   };
 };


### PR DESCRIPTION
## 概要
AI生成画面イメージが設計書間で共有される問題を修正しました。

## 修正内容
- MockupSectionのLocalStorageキーを設計書ID別に分離 (`ai-mockup-html-${documentId}`)
- 「画像として保存」ボタンのスタイルを改善（テキスト色・配色統一）
- ボタン間のスペーシングを調整
- テスト用HTMLボタンの削除
- 不要なデバッグログのクリーンアップ

## 解決したIssue
Closes #5

## テスト方法
1. 画面設計書Aで「AIで画面イメージ生成」を実行
2. 画面設計書Bを作成・切り替え
3. 画面設計書BでHTML+CSSが表示されないことを確認
4. 画面設計書Bで別の画面イメージを生成
5. 画面設計書Aに戻り、元のHTML+CSSが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
